### PR TITLE
Add extra_body support

### DIFF
--- a/ag2studio/datamodel.py
+++ b/ag2studio/datamodel.py
@@ -102,6 +102,8 @@ class Skill(SQLModel, table=True):
 class LLMConfig(SQLModel, table=False):
     """Data model for LLM Config for AutoGen"""
 
+    model_config = {"extra": "allow"}
+
     config_list: List[Any] = Field(default_factory=list)
     temperature: float = 0
     cache_seed: Optional[Union[int, None]] = None

--- a/frontend/src/components/types.ts
+++ b/frontend/src/components/types.ts
@@ -30,6 +30,7 @@ export interface ILLMConfig {
   cache_seed?: number | null;
   temperature: number;
   max_tokens: number;
+  extra_body?: Record<string, any> | null;
 }
 
 export interface IAgentConfig {

--- a/frontend/src/components/utils.ts
+++ b/frontend/src/components/utils.ts
@@ -300,6 +300,7 @@ export const sampleAgentConfig = (agent_type: string = "assistant") => {
     timeout: 600,
     cache_seed: null,
     max_tokens: 1000,
+    extra_body: null,
   };
 
   const userProxyConfig: IAgentConfig = {
@@ -373,6 +374,7 @@ export const sampleWorkflowConfig = (type = "twoagents") => {
     timeout: 600,
     cache_seed: null,
     max_tokens: 1000,
+    extra_body: null,
   };
 
   const userProxyConfig: IAgentConfig = {


### PR DESCRIPTION
## Summary
- allow extra fields in LLMConfig datamodel
- expose extra_body on the frontend LLM config type
- include extra_body in sample configs

## Testing
- `python -m py_compile ag2studio/datamodel.py`

------
https://chatgpt.com/codex/tasks/task_e_682802d7287483229ea58f31bfa8ebd0